### PR TITLE
Update README.md to update a O365 CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Setup bash script for the [PnP Starter Kit](https://github.com/SharePoint/sp-sta
   - Set the user who will run the setup script as a taxonomy term store admin
 - Execute
   - `o365 spo connect [tenant admin]`, eg. `o365 spo connect https://contoso-admin.sharepoint.com`
-  - `o365 graph connect`
+  - `o365 graph login`
   - `chmod +x ./setup.sh`
 
 ## Setup


### PR DESCRIPTION
Updates made to Readme file since the Office 365 CLI `graph connect` is deprecated. Use `graph login` instead. 